### PR TITLE
Torba/account fingerprint

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -8,7 +8,7 @@ import type { users } from "@prisma/client";
 import { log } from '~/log.server';
 
 import { driver } from "~/neo4j.server";
-import { Record } from 'neo4j-driver'
+import { Record, session } from 'neo4j-driver'
 
 
 export function flattenTwitterUserPublicMetrics(data: Array<any>) {
@@ -22,6 +22,93 @@ export function flattenTwitterUserPublicMetrics(data: Array<any>) {
     delete obj.entities;
   }
   return data;
+}
+
+export async function deleteUserIndexedTweets(username: string) {
+  const session = driver.session()
+  const res = await session.executeWrite((tx: any) => {
+    return tx.run(`
+    MATCH (u:User {username: $username} )-[:POSTED]->(t:Tweet)
+    DETACH DELETE t
+  `,
+      { username })
+  })
+  let streams;
+  if (res.records.length > 0) {
+    streams = res.records.map((row: Record) => {
+      return row.get("s")
+    })
+  }
+  await session.close()
+  return streams;
+}
+
+export async function getStreamsUserIn(username: string) {
+  const session = driver.session()
+  const res = await session.executeRead((tx: any) => {
+    return tx.run(`
+      MATCH (s:Stream )-[:CONTAINS]->(u:User {username:$username})
+      RETURN s
+  `,
+      { username })
+  })
+  let streams;
+  if (res.records.length > 0) {
+    streams = res.records.map((row: Record) => {
+      return row.get("s")
+    })
+  }
+  await session.close()
+  return streams;
+}
+
+export async function getUserIndexedTweets(username: string,) {
+  //THIS EXCLUDES RETWEETS RIGHT NOW
+  const session = driver.session()
+  // Create a node within a write transaction
+  const res = await session.executeRead((tx: any) => {
+    return tx.run(`
+          MATCH (u:User {username: $username} )-[:POSTED]->(t:Tweet)
+          OPTIONAL MATCH (t)-[relation:REFERENCED]->(refTweet:Tweet)
+          RETURN u,t,collect(refTweet) as refTweet,collect(relation) as rel
+          ORDER by t.created_at DESC
+      `,
+      { username })
+  })
+  let tweets = [];
+  if (res.records.length > 0) {
+    tweets = res.records.map((row: Record) => {
+      return {
+        "tweet": row.get('t'),
+        "author": row.get('u'),
+        "refTweet": row.get('refTweet'),
+        "rel": row.get("rel")
+      }
+    })
+  }
+  await session.close()
+  return tweets;
+}
+
+export async function getUserContextAnnotationFrequency(username: string) {
+  const session = driver.session()
+  const res = await session.executeWrite((tx: any) => {
+    return tx.run(`
+        MATCH (u:User {username: $username})-[r:POSTED]->(t:Tweet)
+        MATCH (t)-[tr:INCLUDED]->(entity)
+        with collect(entity.name) as entity_names 
+        return  apoc.coll.frequencies(entity_names) as frequencies;
+      `, { username: username }
+    )
+  })
+  let frequencies = [];
+  if (res.records.length > 0) {
+    frequencies = res.records.map((row: Record) => {
+      return row.get("frequencies")
+    })
+  }
+  await session.close()
+  return frequencies;
 }
 
 export async function getUserByUsernameDB(username: string) {

--- a/app/routes/streams/$streamName.tsx
+++ b/app/routes/streams/$streamName.tsx
@@ -46,6 +46,8 @@ export async function loader({ request, params }: LoaderArgs) {
         }
     }
 
+    recommendedUsersTested.sort((a, b) => a.properties['public_metrics.followers_count'] - b.properties['public_metrics.followers_count'])
+
 
     let userLists = [];
     const { api, uid, session } = await getClient(request)
@@ -133,12 +135,12 @@ export const action: ActionFunction = async ({
                 } else {
                     user = await createUserDb(user)
                     console.time("addSeedUserToStream")
-                    addedUser = await addSeedUserToStream(api, stream, user)
+                    addedUser = await addSeedUserToStream(stream, user)
                     console.timeEnd("addSeedUserToStream")
                 }
             } else {
                 console.time("addSeedUserToStream")
-                addedUser = await addSeedUserToStream(api, stream, user)
+                addedUser = await addSeedUserToStream(stream, user)
                 console.timeEnd("addSeedUserToStream")
             }
             console.log(`Added user ${user.properties.username} to stream ${stream.properties.name}`)
@@ -385,6 +387,7 @@ export default function StreamDetailsPage() {
                                                 placeholder='Enter any Twitter handle'
                                                 className='flex-1 rounded border-2 border-black px-2 py-1'
                                             />
+                                            <p>{user.properties["public_metrics.followers_count"]}</p>
                                             <button
                                                 type='submit'
                                                 className='ml-2 inline-block rounded border-2 border-black bg-black px-2 py-1 text-white'

--- a/app/routes/streams/me.tsx
+++ b/app/routes/streams/me.tsx
@@ -4,6 +4,9 @@ import { json } from "@remix-run/node";
 import { Form, Link, NavLink, Outlet, useLoaderData } from "@remix-run/react";
 import invariant from "tiny-invariant";
 import { getClient, USER_FIELDS } from '~/twitter.server';
+import { getUserContextAnnotationFrequency, getStreamsUserIn, getUserIndexedTweets } from '~/models/user.server';
+import { D3BarChart, IData } from '~/components/barChart';
+import { TweetSearchAllV2Paginator } from "twitter-api-v2";
 
 
 // type LoaderData = {
@@ -11,20 +14,43 @@ import { getClient, USER_FIELDS } from '~/twitter.server';
 //     tweet: Awaited<ReturnType<typeof getTweet>>;
 // }
 
+
 export async function loader({ request, params }: LoaderArgs) {
     const { api, uid, session } = await getClient(request);
     const meData = await api.v2.me({ "user.fields": USER_FIELDS });
     let user = meData.data;
-    return json(user)
+    const streams = await getStreamsUserIn(user.username)
+    const tweets = await getUserIndexedTweets(user.username)
+    const frequencies = await getUserContextAnnotationFrequency(user.username)
+    frequencies[0].forEach((item: any) => { item.count = item.count.toInt() })
+    return json({ user, frequencies: frequencies[0], streams, tweets })
 };
 
 export default function StreamsPage() {
-    const user = useLoaderData();
-    console.log("-----")
-    console.log(user);
+    const data = useLoaderData();
+    const user = data.user
+    const frequencies = data.frequencies
+    frequencies.sort((a, b) => b.count - a.count);
+    console.log(data.tweets.slice(0, 3))
     return (
         <div>
+            <h1>Streams You are Included In</h1>
+            <ol>
+                {data.streams.map((stream: Node) => {
+                    return (
+                        <li key={stream.properties.name}>
+                            {stream.properties.name}
+                        </li>
+                    )
+                })}
+            </ol>
+            <p>We've indexed {data.tweets.length} tweets, in date ranges for {data.streams.length} streams</p>
+            <br />
+            <section>
+                <h2>Top Tags From Your Tweets</h2>
+                <D3BarChart data={data.frequencies.slice(0, 5)} />
+            </section>
             <pre>{JSON.stringify(user, null, 2)}</pre>
-        </div>
+        </div >
     );
 }


### PR DESCRIPTION
Added these changes on the way to account fingerprint. 

When generating a user preview, i realized it was annoying that we would have a disparate set of date ranges for each user, we pulled tweets for - one date range for each stream that user is in. 

Instead, I added two fields to the User objects in neo4j: `tweetscapeIndexedTweetsEndTime` and `tweetscapeIndexedTweetsStartTime`. 
These atributes are used to ensure that we keep a single continuous range of indexed tweets for users (the draw back is that sometimes, streams will require that we pull more tweets for a user than a really needed for that stream), but we, will have that tweet available forever...

one issue this doesn't address is updating tweet likes,rt,qt counts... but we can get to that later...