### PR TITLE
kikuomax/fix new user crash

### DIFF
--- a/app/routes/streams/index.tsx
+++ b/app/routes/streams/index.tsx
@@ -46,7 +46,7 @@ export async function action({ request }: ActionArgs) {
 
     let userDb = await getUserByUsernameDB(user.username)
     if (!userDb) {
-        createUserDb(flattenTwitterUserPublicMetrics([user])[0])
+        await createUserDb(flattenTwitterUserPublicMetrics([user])[0])
     }
 
     const userOwnedListsNames = (await getUserOwnedTwitterLists(api, user)).map((row) => (row.name));


### PR DESCRIPTION
The app crashed when I logged in as a new user and then created a new stream. This PR fixes the issue.

### How to reproduce the issue

1. Start the app with the neo4j DB empty on localhost.
2. Open `localhost:3000` with a browser.
3. Login as a new user.
4. Create a new stream.
5. You will see the following message on the browser.
   > An unexpected error occurred: Cannot read properties of undefined (reading 'get')

6. You will also see something like the following on the console running the backend.
   ```
   TypeError: Cannot read properties of undefined (reading 'get')
       at createStream (/Users/kikuo/Documents/projects/third-party/tweetscape-streams/app/models/streams.server.ts:301:31)
       at processTicksAndRejections (node:internal/process/task_queues:96:5)
       at action2 (/Users/kikuo/Documents/projects/third-party/tweetscape-streams/app/routes/streams/index.tsx:65:14)
       at Object.callRouteAction (/Users/kikuo/Documents/projects/third-party/tweetscape-streams/build/server.js:35286:18)
       at handleDataRequest (/Users/kikuo/Documents/projects/third-party/tweetscape-streams/build/server.js:40251:22)
       at requestHandler (/Users/kikuo/Documents/projects/third-party/tweetscape-streams/build/server.js:40198:22)
       at /Users/kikuo/Documents/projects/third-party/tweetscape-streams/build/server.js:41580:26
   ```

### Note

I did not get this error after pulling recent commits because Twitter list creation was introduced between user creation and stream creation, and it unintentionally delayed stream creation. However, this would lead to a subtle bug.
